### PR TITLE
fix: don't propagate clicks to synced charts

### DIFF
--- a/src/trace.js
+++ b/src/trace.js
@@ -195,7 +195,7 @@ export default function(Chart) {
 			var syncGroup = this.getOption(chart, 'sync', 'group');
 
 			// fire event for all other linked charts
-			if (!e.stop && syncEnabled) {
+			if (!e.stop && syncEnabled && e.type !== 'click') {
 				var event = new CustomEvent('sync-event');
 				event.chartId = chart.id;
 				event.syncGroup = syncGroup;


### PR DESCRIPTION
Fixes #23